### PR TITLE
Corrige estrutura do post no Firebase

### DIFF
--- a/webscraper/webscraper.py
+++ b/webscraper/webscraper.py
@@ -7,15 +7,13 @@ from firebase import firebase   # firebase da biblioteca python-firebase
 # Conecta com o firebase configurado
 fb = firebase.FirebaseApplication('https://eng-soft-f1c51.firebaseio.com', None)
 
-
 # Pega os eventos contidos no nó 'path' do firebase
 def getFirebase(path):
 	result = fb.get(path, None)
 	print(result)
 
 # Posta um evento no firebase
-def postFirebase(json, path):
-	user = 'admin'
+def postFirebase(path, json):
 	result = fb.post(path, json)
 	print(result)
 
@@ -59,10 +57,8 @@ def getICMC():
 		else :					# Link Externo
 			data['href'] = l['href']
 
-		# pega o dicionário, transforma em um JSON e posta no firebase 
-		json_data = json.dumps(data)
-		print(json_data)
-		postFirebase(json_data, '/events')
+		# pega o dicionário, e posta no firebase 
+		postFirebase('/events', data)
 
 # Main
 def main():


### PR DESCRIPTION
Os dados estão sendo salvos dentro de uma única string. Proponho guardar de forma estruturada, por exemplo:
```
<id_do_evento>:
    title: "Foo"
    date: "xx/xx/xxxx"
    href: "https://example.com"
    img: "https://example.image.com"
    tags:
        0: ICMC
        1: eventos
```

Ainda manter atenção às recomendações: https://firebase.google.com/docs/database/web/structure-data?authuser=0#avoid_nesting_data

BTW, removi o `json.dumps` porque ele [já faz isso na biblioteca python-firebase](https://github.com/ozgur/python-firebase/blob/master/firebase/firebase.py#L339)